### PR TITLE
fix: remove un-used elements from jsonld context

### DIFF
--- a/contexts/v0.1.jsonld
+++ b/contexts/v0.1.jsonld
@@ -10,7 +10,5 @@
     "Bls12381G2Key2020": "lds:Bls12381G2Key2020"
 
     "requiredRevealStatements": "lds:requiredRevealStatements"
-    "revealedStatements": "lds:revealedStatements"
-    "totalStatements": "lds:totalStatements"
   }
 }


### PR DESCRIPTION
#30 removed these members from the specification, however these members were not removed from the JSON-LD context. Because this JSON-LD context is un-published and this signature scheme is still experimental they are safe to remove.