### PR TITLE
fixes the Bls12381G2Key2020 example to be proper length

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@ and smaller to create rather than key generation.
           "id": "did:example:123456789abcdefghi#keys-1",
           "type": "Bls12381G2Key2020",
           "controller": "did:example:123456789abcdefghi",
-          "publicKeyBase58" : "H3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+          "publicKeyBase58" : "oqpWYKaZD9M1Kbe94BVXpr8WTdFBNZyKv48cziTiQUeuhm7sBhCABMyYG4kcMrseC68YTFFgyhiNeBKjzdKk9MiRWuLv5H4FFujQsQK2KTAtzU8qTBiZqBHMmnLF4PL7Ytu"
         }
       </pre>
   </section>


### PR DESCRIPTION
I realized when I was looking at the examples here that the length of the G2 public key example was too short, so I've updated it to be of proper length.