### PR TITLE
add Bls12381G1Key2020 to context

### DIFF
--- a/contexts/v1/index.json
+++ b/contexts/v1/index.json
@@ -87,6 +87,7 @@
         }
       }
     },
+    "Bls12381G1Key2020": "https://w3id.org/security#Bls12381G1Key2020",
     "Bls12381G2Key2020": "https://w3id.org/security#Bls12381G2Key2020"
   }
 }


### PR DESCRIPTION
Adding the vocabulary defined in:
https://w3c-ccg.github.io/ldp-bbs2020/#bls-12-381-g1-public-key

to the context.