### PR TITLE
fix: update digest algorithm used by reference implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,11 +145,9 @@
             authors:  ["Michael Lodder", "Tobias Looker"],
             status:   "Draft"
           },
-          "SHA-3": {
-            title:    "SHA-3 Standard: Permutation-Based Has and Extendable-Output Functions",
-            href:     "https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf",
-            status:   "Published",
-            publisher:  "NIST"
+          "BLAKE2": {
+            title:    "Blake2 - fast secure hashing",
+            href:     "https://www.blake2.net/",
           }
         }
       };
@@ -469,8 +467,8 @@ and smaller to create rather than key generation.
                   </tr>
                   <tr>
                     <td><a>statement digest algorithm</a></td>
-                    <td>SHAKE-256</td>
-                    <td>[[SHA-3]]</td>
+                    <td>Blake2b</td>
+                    <td>[[BLAKE2]]</td>
                   </tr>
                   <tr>
                     <td><a>signature algorithm</a></td>


### PR DESCRIPTION
Both the current reference implementations use Blake2b as the digest function instead of SHAKE, so this PR is a correction, future versions of the suite may elect to use SHAKE-256