### PR TITLE
fix: update signature to proofValue

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,8 +566,8 @@ and smaller to create rather than key generation.
                 "created": "2020-04-25",
                 "verificationMethod": "did:example:489398593#test",
                 "proofPurpose": "assertionMethod",
-                "requiredRevealStatements": [ 4, 5 ],
-                "signature": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg=="
+                "proofValue": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg==",
+                "requiredRevealStatements": [ 4, 5 ]
               }
             }
           </pre>
@@ -605,8 +605,8 @@ and smaller to create rather than key generation.
                 <span class="highlight">"created": "2020-04-25"</span>,
                 "verificationMethod": "did:example:489398593#test",
                 "proofPurpose": "assertionMethod",
-                "requiredRevealStatements": [ 4, 5 ],
-                "signature": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg=="
+                "proofValue": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg==",
+                "requiredRevealStatements": [ 4, 5 ]
               }
             }
           </pre>
@@ -641,8 +641,8 @@ and smaller to create rather than key generation.
                 "created": "2020-04-25",
                 "verificationMethod": "did:example:489398593#test",
                 "proofPurpose": "assertionMethod",
-                "requiredRevealStatements": [ 4, 5 ],
-                "signature": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg=="
+                "proofValue": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg==",
+                "requiredRevealStatements": [ 4, 5 ]
               }
             }
           </pre>
@@ -684,8 +684,8 @@ and smaller to create rather than key generation.
                 "created": "2020-04-25",
                 <span class="highlight">"verificationMethod": "did:example:489398593#test"</span>,
                 "proofPurpose": "assertionMethod",
-                "requiredRevealStatements": [ 4, 5 ],
-                "signature": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg=="
+                "proofValue": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg==",
+                "requiredRevealStatements": [ 4, 5 ]
               }
             }
           </pre>
@@ -722,8 +722,8 @@ and smaller to create rather than key generation.
                 "created": "2020-04-25",
                 "verificationMethod": "did:example:489398593#test",
                 <span class="highlight">"proofPurpose": "assertionMethod"</span>,
-                "requiredRevealStatements": [ 4, 5 ],
-                "signature": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg=="
+                "proofValue": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg==",
+                "requiredRevealStatements": [ 4, 5 ]
               }
             }
           </pre>
@@ -763,22 +763,22 @@ and smaller to create rather than key generation.
                 "created": "2020-04-25",
                 "verificationMethod": "did:example:489398593#test",
                 "proofPurpose": "assertionMethod",
-                <span class="highlight">"requiredRevealStatements": [ 4, 5 ]</span>,
-                "signature": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg=="
+                "proofValue": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg==",
+                <span class="highlight">"requiredRevealStatements": [ 4, 5 ]</span>
               }
             }
           </pre>
         </section>
 
         <section>
-          <h4>Signature</h4>
+          <h4>Proof Value</h4>
 
           <p>
-            The raw signature value outputted by computing a sign operation must feature in the proof, in order for parties to verify the signature.
+            The raw value outputted by computing a sign operation must feature in the proof, in order for parties to verify the signature.
           </p>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ Signature </a>linked data proof</a> MUST contain a <code>signature</code> 
+            A <a>linked data document</a> featuring a BBS+ Signature </a>linked data proof</a> MUST contain a <code>proofValue</code> 
             attribute with value defined by the signing algorithm described in this specification.
           </p>
 
@@ -802,8 +802,8 @@ and smaller to create rather than key generation.
                 "created": "2020-04-25",
                 "verificationMethod": "did:example:489398593#test",
                 "proofPurpose": "assertionMethod",
-                "requiredRevealStatements": [ 4, 5 ],
-                <span class="highlight">"signature": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg=="</span>
+                <span class="highlight">"proofValue": "F9uMuJzNBqj4j+HPTvWjUN/MNoe6KRH0818WkvDn2Sf7kg1P17YpNyzSB+CH57AWDFunU13tL8oTBDpBhODckelTxHIaEfG0rNmqmjK6DOs0/ObksTZh7W3OTbqfD2h4C/wqqMQHSWdXXnojwyFDEg=="</span>,
+                "requiredRevealStatements": [ 4, 5 ]
               }
             }
           </pre>
@@ -1018,7 +1018,7 @@ the following algorithms:
 
           <p>
             A <a>linked data document</a> featuring a BBS+ proof of knowledge </a>linked data proof</a> 
-            MUST contain a <code>proof</code> attribute with value defined by the derive proof algorithm 
+            MUST contain a <code>proofValue</code> attribute with value defined by the derive proof algorithm 
             described in this specification.
           </p>
 


### PR DESCRIPTION
Updates the `signature` property for `BbsBlsSignature2020` to `proofValue`

Fixes #52