### PR TITLE
Update specification structure to align with latest Data Integrity specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,6 +621,291 @@ produced according to [[CFRG-BBS-SIGNATURES]], encoded according to
   </section>
 </section>
 
+  <section>
+    <h2>Algorithms</h2>
+
+    <p>
+The following section describes multiple Data Integrity cryptographic suites
+that utilize the BBS Signature Algorithm [[CFRG-BBS-SIGNATURE]].
+    </p>
+
+    <section>
+    <h3>bbs-2023</h3>
+
+    <p>
+The `bbs-2023` cryptographic suite takes an input document, canonicalizes
+the document using the Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]], and then cryptographically hashes and signs the output
+resulting in the production of a data integrity proof. The algorithms in this
+section also include the verification of such a data integrity proof.
+    </p>
+
+    <section>
+      <h2>Add Proof (bbs-2023)</h2>
+
+      <p>
+To generate a proof, the algorithm in
+<a href="https://www.w3.org/TR/vc-data-integrity/#add-proof">
+Section 4.1: Add Proof</a> in the Data Integrity
+[[VC-DATA-INTEGRITY]] specification MUST be executed.
+For that algorithm, the cryptographic suite specific
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
+transformation algorithm</a> is defined in Section
+<a href="#transformation-bbs-2023"></a>, the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
+hashing algorithm</a> is defined in Section <a href="#hashing-bbs-2023"></a>,
+and the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
+proof serialization algorithm</a> is defined in Section
+<a href="#proof-serialization-bbs-2023"></a>.
+      </p>
+    </section>
+
+    <section>
+      <h2>Verify Proof (bbs-2023)</h2>
+
+      <p>
+To verify a proof, the algorithm in
+<a href="https://www.w3.org/TR/vc-data-integrity/#verify-proof">
+Section 4.2: Verify Proof</a> in the Data Integrity
+[[VC-DATA-INTEGRITY]] specification MUST be executed.
+For that algorithm, the cryptographic suite specific
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-transformation-algorithm">
+transformation algorithm</a> is defined in Section
+<a href="#transformation-bbs-2023"></a>, the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-hashing-algorithm">
+hashing algorithm</a> is defined in Section <a href="#hashing-bbs-2023"></a>,
+and the
+<a href="https://www.w3.org/TR/vc-data-integrity/#dfn-proof-serialization-algorithm">
+proof verification algorithm</a> is defined in Section
+<a href="#proof-verification-bbs-2023"></a>.
+      </p>
+    </section>
+
+    <section>
+      <h3>Transformation (bbs-2023)</h3>
+
+      <p>
+The following algorithm specifies how to transform an unsecured input document
+into a transformed document that is ready to be provided as input to the
+hashing algorithm in Section <a href="#hashing-bbs-2023"></a>.
+      </p>
+
+
+Required inputs to this algorithm are an
+<a href="https://w3c.github.io/vc-data-integrity/#dfn-unsecured-data-document">
+unsecured data document</a> (<var>unsecuredDocument</var>) and
+<a href="https://w3c.github.io/vc-data-integrity/#dfn-transformation-options">
+transformation options</a> (<var>options</var>). The
+<a href="https://w3c.github.io/vc-data-integrity/#dfn-unsecured-data-document">
+transformation options</a> MUST contain a type identifier for the
+<a href="https://w3c.github.io/vc-data-integrity/#dfn-cryptographic-suite">
+cryptographic suite</a> (<var>type</var>) and a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>transformed data document</em> is
+produced as output. Whenever this algorithm encodes strings, it MUST use UTF-8
+encoding.
+      </p>
+
+      <ol class="algorithm">
+        <li>
+If <var>options</var>.<var>type</var> is not set to the string
+`DataIntegrityProof` and <var>options</var>.<var>cryptosuite</var> is not
+set to the string `bbs-2023` then a `PROOF_TRANSFORMATION_ERROR` MUST be
+raised.
+        </li>
+        <li>
+Let <var>canonicalDocument</var> be the result of applying the
+Universal RDF Dataset Canonicalization Algorithm
+[[RDF-CANON]] to the <var>unsecuredDocument</var>.
+        </li>
+        <li>
+Set <var>output</var> to the value of <var>canonicalDocument</var>.
+        </li>
+        <li>
+Return <var>canonicalDocument</var> as the <em>transformed data document</em>.
+        </li>
+      </ol>
+    </section>
+
+    <section>
+      <h3>Hashing (bbs-2023)</h3>
+
+      <p>
+The following algorithm specifies how to cryptographically hash a
+<em>transformed data document</em> and <em>proof configuration</em>
+into cryptographic hash data that is ready to be provided as input to the
+algorithms in Section <a href="#proof-serialization-bbs-2023"></a> or
+Section <a href="#proof-verification-bbs-2023"></a>.
+      </p>
+
+      <p>
+The required inputs to this algorithm are a <em>transformed data document</em>
+(<var>transformedDocument</var>) and <em>proof configuration</em>
+(<var>proofConfig</var>). A single <em>hash data</em> value represented as
+series of bytes is produced as output.
+      </p>
+
+      <ol class="algorithm">
+        <li>
+Let <var>transformedDocumentHash</var> be the result of applying the
+SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
+to the <var>transformedDocument</var>. <var>transformedDocumentHash</var> will
+be exactly 32 bytes in size.
+        </li>
+        <li>
+Let <var>proofConfigHash</var> be the result of applying the
+SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
+to the <var>proofConfig</var>. <var>proofConfigHash</var> will be
+exactly 32 bytes in size.
+        </li>
+        <li>
+Let <var>hashData</var> be the result of joining <var>proofConfigHash</var> (the
+first hash) with <var>transformedDocumentHash</var> (the second hash).
+        </li>
+        <li>
+Return <var>hashData</var> as the <em>hash data</em>.
+        </li>
+      </ol>
+
+    </section>
+
+    <section>
+      <h3>Proof Configuration (bbs-2023)</h3>
+
+      <p>
+The following algorithm specifies how to generate a
+<em>proof configuration</em> from a set of <em>proof options</em>
+that is used as input to the <a href="#hashing-bbs-2023">proof hashing algorithm</a>.
+      </p>
+
+      <p>
+The required inputs to this algorithm are <em>proof options</em>
+(<var>options</var>). The <em>proof options</em> MUST contain a type identifier
+for the
+<a href="https://w3c.github.io/vc-data-integrity/#dfn-cryptographic-suite">
+cryptographic suite</a> (<var>type</var>) and MUST contain a cryptosuite
+identifier (<var>cryptosuite</var>). A <em>proof configuration</em>
+object is produced as output.
+      </p>
+
+      <ol class="algorithm">
+        <li>
+Let <var>proofConfig</var> be an empty object.
+        </li>
+        <li>
+Set <var>proofConfig</var>.<var>type</var> to
+<var>options</var>.<var>type</var>.
+        </li>
+        <li>
+If <var>options</var>.<var>cryptosuite</var> is set, set
+<var>proofConfig</var>.<var>cryptosuite</var> to its value.
+        </li>
+        <li>
+If <var>options</var>.<var>type</var> is not set to `DataIntegrityProof` and
+<var>proofConfig</var>.<var>cryptosuite</var> is not set to `bbs-2023`, an
+`INVALID_PROOF_CONFIGURATION` error MUST be raised.
+        </li>
+        <li>
+Set <var>proofConfig</var>.<var>created</var> to
+<var>options</var>.<var>created</var>. If the value is not a valid
+[[XMLSCHEMA11-2]] datetime, an `INVALID_PROOF_DATETIME` error MUST be raised.
+        </li>
+        <li>
+Set <var>proofConfig</var>.<var>verificationMethod</var> to
+<var>options</var>.<var>verificationMethod</var>.
+        </li>
+        <li>
+Set <var>proofConfig</var>.<var>proofPurpose</var> to
+<var>options</var>.<var>proofPurpose</var>.
+        </li>
+        <li>
+Return <var>proofConfig</var>.
+        </li>
+      </ol>
+
+    </section>
+
+    <section>
+      <h3>Proof Serialization (bbs-2023)</h3>
+
+      <p>
+The following algorithm specifies how to serialize a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a href="https://w3c.github.io/vc-data-integrity/#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>) and
+<em>proof options</em> (<var>options</var>). The
+<em>proof options</em> MUST contain a type identifier for the
+<a href="https://w3c.github.io/vc-data-integrity/#dfn-cryptographic-suite">
+cryptographic suite</a> (<var>type</var>) and MAY contain a cryptosuite
+identifier (<var>cryptosuite</var>). A single <em>digital proof</em> value
+represented as series of bytes is produced as output.
+      </p>
+
+      <ol class="algorithm">
+        <li>
+Let <var>privateKeyBytes</var> be the result of retrieving the
+private key bytes associated with the
+<var>options</var>.<var>verificationMethod</var> value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a href="https://w3c.github.io/vc-data-integrity/#algorithms">
+Section 4: Retrieving Cryptographic Material</a>.
+        </li>
+        <li>
+Let <var>proofBytes</var> be the result of applying the BBS Signature
+Algorithm [[CFRG-BBS]], with <var>hashData</var> as the data
+to be signed using the private key specified by <var>privateKeyBytes</var>.
+<var>proofBytes</var> will be exactly 64 bytes in size for a P-256 key, and
+96 bytes in size for a P-384 key.
+        </li>
+        <li>
+Return <var>proofBytes</var> as the <em>digital proof</em>.
+        </li>
+      </ol>
+
+    </section>
+
+    <section>
+      <h3>Proof Verification (bbs-2023)</h3>
+
+      <p>
+The following algorithm specifies how to verify a digital signature from
+a set of cryptographic hash data. This
+algorithm is designed to be used in conjunction with the algorithms defined
+in the Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a href="https://w3c.github.io/vc-data-integrity/#algorithms">
+Section 4: Algorithms</a>. Required inputs are
+cryptographic hash data (<var>hashData</var>),
+a digital signature (<var>proofBytes</var>) and
+proof options (<var>options</var>). A <em>verification result</em>
+represented as a boolean value is produced as output.
+      </p>
+
+      <ol class="algorithm">
+        <li>
+Let <var>publicKeyBytes</var> be the result of retrieving the
+public key bytes associated with the
+<var>options</var>.<var>verificationMethod</var> value as described in the
+Data Integrity [[VC-DATA-INTEGRITY]] specification,
+<a href="https://w3c.github.io/vc-data-integrity/#algorithms">
+Section 4: Retrieving Cryptographic Material</a>.
+        </li>
+        <li>
+Let <var>verificationResult</var> be the result of applying the verification
+algorithm defined in the BBS Signature specification [[CFRG-BBS]],
+with <var>hashData</var> as the data to be verified against the
+<var>proofBytes</var> using the public key specified by
+<var>publicKeyBytes</var>.
+        </li>
+        <li>
+Return <var>verificationResult</var> as the <em>verification result</em>.
+        </li>
+      </ol>
+
+    </section>
+  </section>
 </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>BBS+ Signatures 2020</title>
+    <title>BBS Cryptosuite v2023</title>
     <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
     <!--
       === NOTA BENE ===
@@ -346,6 +346,282 @@ In short, it is a node in a graph that is neither an IRI, nor a literal.
       </section>
     </section>
 
+    <section>
+      <h2>Data Model</h2>
+
+      <p>
+The following sections outline the data model that is used by this specification
+for <a>verification methods</a> and <a>data integrity proof</a> formats.
+      </p>
+
+      <section>
+        <h2>Verification Methods</h2>
+        <p>
+The cryptographic material used to verify a <a>data integrity proof</a> is
+called the <a>verification method</a>. This suite relies on public key material
+represented using [[MULTIBASE]], [[MULTICODEC]], and JSON Web Key [[RFC7517]].
+        </p>
+
+        <p>
+This suite MAY be used to verify Data Integrity Proofs [[VC-DATA-INTEGRITY]]
+produced by BLS12-381 public key material encoded as a
+<a href="#multikey">Multikey</a>. Loss-less key transformation processes that
+result in equivalent cryptographic material MAY be utilized.
+        </p>
+
+        <section>
+          <h3>Multikey</h3>
+
+          <p class="issue">
+This definition should go in the Data Integrity specification and referenced
+from there.
+          </p>
+
+          <p>
+The `type` of the verification method MUST be `Multikey`.
+          </p>
+
+          <p>
+The `controller` of the verification method MUST be a URL.
+          </p>
+
+          <p>
+The `publicKeyMultibase` property of the verification method MUST be a public
+key encoded according to [[MULTICODEC]] and formatted according to
+[[MULTIBASE]]. The multicodec encoding of a BLS12-381 public key that combines
+both the G1 and G2 fields is the byte prefix `0xee` followed by the 48-byte G1
+public key data, which is then followed by the 96-byte G2 public key data. The
+145 byte value is then encoded using base64url with no padding (`u`) as the
+prefix. Any other encodings MUST NOT be allowed.
+          </p>
+
+          <p class="advisement">
+Developers are advised to not accidentally publish a representation of a private
+key. Implementations of this specification will raise errors in the event of a
+[[MULTICODEC]] value other than `0xee` being used in a `publicKeyMultibase`
+value.
+          </p>
+
+          <pre class="example"
+            title="An BLS12-381 public key containing the G1 and G2 values, encoded as a Multikey">
+{
+  "id": "https://example.com/issuer/123#key-0",
+  "type": "Multikey",
+  "controller": "https://example.com/issuer/123",
+  "publicKeyMultibase": "u7ljnAxKdp7YVqJvcMU9GtnmrMc1XZztXHsTsZ2LsmGJ67SsdbmNc
+    S2SDs0daEPfhVXgODk0IVrgguJ-TJACHyXYa9Ae8DaxcvRy89KLgmWsyOOJn2oY7vCE2gt
+    JoebMJiQsdbmNcS2SDs0daEPfhVXgODk0IVrgguJ-TJACHyXYa9Ae8DaxcvRy89KLgm"
+}
+          </pre>
+
+          <pre class="example" title="A BLS12-381 public key containing the
+            G1 and G2 values, encoded as a Multikey in a controller document">
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/data-integrity/v1"
+  ],
+  "id": "did:example:123",
+  "verificationMethod": [{
+    "id": "https://example.com/issuer/123#key-1",
+    "type": "Multikey",
+    "controller": "https://example.com/issuer/123",
+    "publicKeyMultibase": "zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
+  }, {
+    "id": "https://example.com/issuer/123#key-2",
+    "type": "Multikey",
+    "controller": "https://example.com/issuer/123",
+    "publicKeyMultibase": "u7ljnAxKdp7YVqJvcMU9GtnmrMc1XZztXHsTsZ2LsmGJ67SsdbmNc
+      S2SDs0daEPfhVXgODk0IVrgguJ-TJACHyXYa9Ae8DaxcvRy89KLgmWsyOOJn2oY7vCE2gt
+      JoebMJiQsdbmNcS2SDs0daEPfhVXgODk0IVrgguJ-TJACHyXYa9Ae8DaxcvRy89KLgm"
+  }],
+  "authentication": [
+    "did:example:123#key-1"
+  ],
+  "assertionMethod": [
+    "did:example:123#key-2"
+  ],
+  "capabilityDelegation": [
+    "did:example:123#key-1"
+  ],
+  "capabilityInvocation": [
+    "did:example:123#key-1"
+  ]
+}
+          </pre>
+        </section>
+
+        <section>
+          <h3>JsonWebKey</h3>
+
+          <p class="issue">
+This definition should go in the Data Integrity specification and referenced
+from there.
+          </p>
+
+          <p>
+The `type` of the verification method MUST be `JsonWebKey`.
+          </p>
+
+          <p>
+The `controller` of the verification method MUST be a URL.
+          </p>
+
+          <p>
+The `publicKeyJwk` property of the verification method MUST be a public
+key encoded according to [[RFC7517]]. Any other encodings MUST NOT be allowed.
+          </p>
+
+          <p class="issue">
+The specific encoding of BBS public key parameters are being discussed in the
+JOSE Working Group.
+          </p>
+
+          <p class="advisement">
+Developers are advised to not accidentally publish a representation of a private
+key. Implementations of this specification MUST raise errors in the event of
+the expression of a key parameter that is marked as `Private` in the IANA
+JSON Web Key Parameters registry in public key information.
+          </p>
+
+          <pre class="example"
+            title="An BLS12-381 public key containing the G1 and G2 values, encoded as a JsonWebKey">
+{
+  "id": "did:example:123#key-3",
+  "type": "JsonWebKey",
+  "controller": "did:example:123",
+  "publicKeyJwk": [{
+    "kty": "EC",
+    "crv": "BLS12381_G1",
+    "x": "tCgCNuUYQotPEsrljWi-lIRIPpzhqsnJV1NPnE7je6glUb-FJm9IYkuv2hbHw22i"
+  }, {
+    "kty": "EC",
+    "crv": "BLS12381_G2",
+    "x": "h_rkcTKXXzRbOPr9UxSfegCbid2U_cVNXQUaKeGF7UhwrMJFP70uMH0VQ9-3-_2zDP
+      AAjflsdeLkOXW3-ShktLxuPy8UlXSNgKNmkfb-rrj-FRwbs13pv_WsIf-eV66-"
+  }]
+}
+          </pre>
+
+          <pre class="example" title="A BLS12-381 public key containing the
+            G1 and G2 values, encoded as a JsonWebKey in a controller document">
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/data-integrity/v1"
+  ],
+  "id": "did:example:123",
+  "verificationMethod": [{
+    "id": "https://example.com/issuer/123#key-3",
+    "type": "Multikey",
+    "controller": "https://example.com/issuer/123",
+    "publicKeyMultibase": "zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
+  }, {
+    "id": "did:example:123#key-3",
+    "type": "JsonWebKey",
+    "controller": "did:example:123",
+    "publicKeyJwk": [{
+      "kty": "EC",
+      "crv": "BLS12381_G1",
+      "x": "tCgCNuUYQotPEsrljWi-lIRIPpzhqsnJV1NPnE7je6glUb-FJm9IYkuv2hbHw22i"
+    }, {
+      "kty": "EC",
+      "crv": "BLS12381_G2",
+      "x": "h_rkcTKXXzRbOPr9UxSfegCbid2U_cVNXQUaKeGF7UhwrMJFP70uMH0VQ9-3-_2zDP
+        AAjflsdeLkOXW3-ShktLxuPy8UlXSNgKNmkfb-rrj-FRwbs13pv_WsIf-eV66-"
+    }]
+  }],
+  "authentication": [
+    "did:example:123#key-3"
+  ],
+  "assertionMethod": [
+    "did:example:123#key-4"
+  ],
+  "capabilityDelegation": [
+    "did:example:123#key-3"
+  ],
+  "capabilityInvocation": [
+    "did:example:123#key-3"
+  ]
+}
+          </pre>
+        </section>
+
+      </section>
+
+    <section>
+      <h2>Proof Representations</h2>
+
+      <p>
+This suite relies on detached digital signatures represented using [[MULTIBASE]]
+and [[MULTICODEC]].
+      </p>
+
+      <section>
+        <h3>DataIntegrityProof</h3>
+
+        <p>
+The `verificationMethod` property of the proof MUST be a URL.
+Dereferencing the `verificationMethod` MUST result in an object
+containing a `type` property with the value set to
+`Multikey` or `JsonWebKey`.
+        </p>
+
+        <p>
+The `type` property of the proof MUST be `DataIntegrityProof`.
+        </p>
+        <p>
+The `cryptosuite` property of the proof MUST be `bbs-2023`.
+        </p>
+        <p>
+The `created` property of the proof MUST be an [[XMLSCHEMA11-2]]
+formated date string.
+        </p>
+        <p>
+The `proofPurpose` property of the proof MUST be a string, and MUST
+match the verification relationship expressed by the verification method
+`controller`.
+        </p>
+        <p>
+The `proofValue` property of the proof MUST be a detached BBS Signature
+produced according to [[CFRG-BBS-SIGNATURES]], encoded according to
+[[MULTIBASE]] using the base64 base encoding with no padding.
+        </p>
+
+        <pre class="example highlight" style="overflow-x:
+          auto; white-space: pre-wrap; word-wrap: break-word;"
+          title="An BBS digital signature expressed as a DataIntegrityProof">
+{
+  "@context": [
+    {"title": "https://schema.org/title"},
+    "https://w3id.org/security/data-integrity/v1"
+  ],
+  "title": "Hello world!",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "bbs-2023",
+    "created": "2020-11-05T19:23:24Z",
+    "verificationMethod": "https://example.com/issuer/123#key-2",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "mU6i3dTz5yFfWJ8zgsamuyZa4yAHPm75tUOOXddR6krCvCYk77sbCOuEVcdB
+      Dd/l6tIYkTTbA3pmDa6Qia/JkOnIXDLmoBz3vsi7L5t3DWySI/VLmBqleJ/Tbus5RoyiDERDB
+      5rnACXlnOqJ/U8yFQFtcp/mBCc2FtKNPHae9jKIv1dm9K9QK1F3GI1AwyGoUfjLWrkGDObO1o
+      AhpEd0+et+qiOf2j8p3MTTtRRx4Hgjcl0jXCq7C7R5/nLpgimHAAAAdAx4ouhMk7v9dXijCIM
+      0deicn6fLoq3GcNHuH5X1j22LU/hDu7vvPnk/6JLkZ1xQAAAAIPd1tu598L/K3NSy0zOy6oba
+      Enaqc1R5Ih/6ZZgfEln2a6tuUp4wePExI1DGHqwj3j2lKg31a/6bSs7SMecHBQdgIYHnBmCYG
+      nu/LZ9TFV56tBXY6YOWZgFzgLDrApnrFpixEACM9rwrJ5ORtxAAAAAgE4gUIIC9aHyJNa5TBk
+      Oh6ojlvQkMVLXa/vEl+3NCLXblxjgpM7UEMqBkE9/aGQcoD3Tgmy+z0hN+4elMky1RnJEhCuN
+      QNsEg"
+  }
+}
+        </pre>
+
+      </section>
+    </section>
+  </section>
+</section>
+
+</section>
 
     <section>
       <h2>Security Considerations</h2>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@
       For the three scripts below, if your spec resides on dev.w3 you can check them
       out in the same tree and use relative links so that they'll work offline,
      -->
-    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
+    <script class='remove' src="https://w3c.github.io/vc-data-integrity/common.js"></script>
+
     <script type="text/javascript" class="remove">
       var respecConfig = {
         // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
@@ -16,6 +18,8 @@
 
         // the specification's short name, as in http://www.w3.org/TR/short-name/
         shortName:            "lds-bbs",
+        subtitle: "Achieving Data Integrity using Unlinkable BBS Signatures",
+        group: "credentials",
 
         // if you wish the publication date to be other than today, set this
         // publishDate:  "2009-08-06",
@@ -139,12 +143,37 @@
             status:   "Internet Draft",
             publisher:  "IETF"
           },
+          "VC-DATA-MODEL-2": {
+            title: "Verifiable Credentials Data Model v2.0",
+            href: "https://www.w3.org/TR/vc-data-model-2.0/",
+            authors: [
+              "Manu Sporny", "Dave Longley", "Grant Noble", "Dan Burnett",
+              "Ted Thibodeau", "Brent Zundel", "David Chadwick",
+              "Kyle Den Hartog"
+            ],
+            status: "Working Draft",
+            publisher: "W3C Verifiable Credentials Working Group"
+          },
           "SHORT-GROUP-SIGNATURES": {
             title:    "Short group signatures",
             href:     "https://crypto.stanford.edu/~xb/crypto04a/groupsigs.pdf",
             authors:  ["Dan Boneh", "Xavier Boyen", "Hovav Shacham"],
             status:   "Published",
             publisher:  "Advances in Cryptology—CRYPTO 2004"
+          },
+          MULTIBASE: {
+            title: "Multibase",
+            href: "https://tools.ietf.org/html/draft-multiformats-multibase-01",
+          },
+          MULTICODEC: {
+            title: "Multicodec",
+            href: "https://github.com/multiformats/multicodec/",
+          },
+          "CFRG-BBS-SIGNATURE": {
+            title:    "The BBS Signature Scheme",
+            href:     "https://www.ietf.org/archive/id/draft-irtf-cfrg-bbs-signatures-02.html",
+            authors:  ["Tobias Looker", "Vasilis Kalos", "Andrew Whitehead", "Mike Lodder"],
+            status:   "Draft"
           },
           "BBS": {
             title:    "BBS+ Signatures",
@@ -156,7 +185,9 @@
             title:    "Blake2 - fast secure hashing",
             href:     "https://www.blake2.net/",
           }
-        }
+        },
+        lint: {"no-unused-dfns": false},
+        postProcess: [restrictRefs]
       };
     </script>
         <style>
@@ -227,6 +258,8 @@ The following terms are used to describe concepts involved in the
 generation and verification of the Data Integrity
 <a>signature suite</a>.
       </p>
+
+      <div data-include="https://w3c.github.io/vc-data-integrity/terms.html"></div>
 
       <dl>
         <dt><dfn>signature suite</dfn></dt>
@@ -300,11 +333,6 @@ A <a href="https://json-ld.github.io/normalization/spec/index.html#dfn-quad" cla
       <dt><dfn data-lt="n-quad|n-quads">n-quad</dfn></dt>
       <dd>
 An <a href="https://www.w3.org/TR/n-quads/" class="externalDFN">n-quad</a> which is a line based, plain text format encoding of a <a>quad</a> as defined by [[RDF-N-Quads]].
-      </dd>
-      <dt><dfn data-lt="data integrity proof|data integrity proofs">data integrity proof</dfn></dt>
-      <dd>
-A <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-data-integrity-proof" class="externalDFN">data integrity proof</a>
-which is a set of attributes that represent a linked data digital proof and the parameters required to verify it as defined by [[RDF-N-Quads]].
       </dd>
       <dt><dfn data-lt="linked data document|linked data documents">linked data document</dfn></dt>
       <dd>
@@ -584,7 +612,7 @@ match the verification relationship expressed by the verification method
         </p>
         <p>
 The `proofValue` property of the proof MUST be a detached BBS Signature
-produced according to [[CFRG-BBS-SIGNATURES]], encoded according to
+produced according to [[CFRG-BBS-SIGNATURE]], encoded according to
 [[MULTIBASE]] using the base64 base encoding with no padding.
         </p>
 
@@ -855,7 +883,7 @@ Section 4: Retrieving Cryptographic Material</a>.
         </li>
         <li>
 Let <var>proofBytes</var> be the result of applying the BBS Signature
-Algorithm [[CFRG-BBS]], with <var>hashData</var> as the data
+Algorithm [[CFRG-BBS-SIGNATURE]], with <var>hashData</var> as the data
 to be signed using the private key specified by <var>privateKeyBytes</var>.
 <var>proofBytes</var> will be exactly 64 bytes in size for a P-256 key, and
 96 bytes in size for a P-384 key.
@@ -894,7 +922,7 @@ Section 4: Retrieving Cryptographic Material</a>.
         </li>
         <li>
 Let <var>verificationResult</var> be the result of applying the verification
-algorithm defined in the BBS Signature specification [[CFRG-BBS]],
+algorithm defined in the BBS Signature specification [[CFRG-BBS-SIGNATURE]],
 with <var>hashData</var> as the data to be verified against the
 <var>proofBytes</var> using the public key specified by
 <var>publicKeyBytes</var>.
@@ -1961,7 +1989,7 @@ value of <code>BbsBoundSignatureProof2020</code>.
             </li>
             <li>
               Record the total number of <a>statements</a> in the <a>input proof document statements</a>.
-              Let this be known as the <a>total statements</a>.
+              Let this be known as the <dfn>total statements</dfn>.
             </li>
             <li>
               Apply the <a>framing algorithm</a> to the <a>input proof document</a>. Let the product of the <a>framing algorithm</a> be
@@ -1973,7 +2001,7 @@ value of <code>BbsBoundSignatureProof2020</code>.
             </li>
             <li>
               Initialize an empty array of length equal to the number of <a>revealed statements</a>.
-              Let this be known as the <a>revealed indicies</a> array.
+              Let this be known as the <dfn>revealed indicies</dfn> array.
             </li>
             <li>For each <a>statement</a> in order:
               <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -774,21 +774,16 @@ series of bytes is produced as output.
       </p>
 
       <ol class="algorithm">
-        <li>
-Let <var>transformedDocumentHash</var> be the result of applying the
-SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-to the <var>transformedDocument</var>. <var>transformedDocumentHash</var> will
-be exactly 32 bytes in size.
+        <li class="issue">
+Specify how each item in the canonicalized input is hashed and included a set
+that is then signed over in <a href="#proof-serialization-bbs-2023"></a>.
         </li>
-        <li>
-Let <var>proofConfigHash</var> be the result of applying the
-SHA-256 (SHA-2 with 256-bit output) cryptographic hashing algorithm [[RFC6234]]
-to the <var>proofConfig</var>. <var>proofConfigHash</var> will be
-exactly 32 bytes in size.
+        <li class="issue">
+Specify how <var>proofConfigHash</var> is generated.
         </li>
-        <li>
-Let <var>hashData</var> be the result of joining <var>proofConfigHash</var> (the
-first hash) with <var>transformedDocumentHash</var> (the second hash).
+        <li class="issue">
+Specify how <var>hashData</var> is composed in a way that can be signed over in
+<a href="#proof-serialization-bbs-2023"></a>.
         </li>
         <li>
 Return <var>hashData</var> as the <em>hash data</em>.
@@ -881,12 +876,9 @@ Data Integrity [[VC-DATA-INTEGRITY]] specification,
 <a href="https://w3c.github.io/vc-data-integrity/#algorithms">
 Section 4: Retrieving Cryptographic Material</a>.
         </li>
-        <li>
-Let <var>proofBytes</var> be the result of applying the BBS Signature
-Algorithm [[CFRG-BBS-SIGNATURE]], with <var>hashData</var> as the data
-to be signed using the private key specified by <var>privateKeyBytes</var>.
-<var>proofBytes</var> will be exactly 64 bytes in size for a P-256 key, and
-96 bytes in size for a P-384 key.
+        <li class="issue">
+Specify how <var>proofBytes</var> is generated and consumed by Section
+<a href="#proof-verification-bbs-2023"></a>.
         </li>
         <li>
 Return <var>proofBytes</var> as the <em>digital proof</em>.

--- a/index.html
+++ b/index.html
@@ -207,19 +207,18 @@ is not fit for production deployment.
       <h2>Introduction</h2>
       <p>
 This specification defines a set of cryptographic suites for the purpose of creating, verifying and deriving proofs
-for BBS+ Signatures in conformance with the Data Integrity [[DATA-INTEGRITY]] specification. 
+for BBS+ Signatures in conformance with the Data Integrity [[DATA-INTEGRITY]] specification.
       </p>
       <p>
 In general the suites uses the RDF Dataset Normalization Algorithm [[RDF-DATASET-NORMALIZATION]] to transform an
-input document into its canonical form. It then uses the <a>statement digest algorithm</a> 
+input document into its canonical form. It then uses the <a>statement digest algorithm</a>
 to digest each statement to be signed individually, finally the digested statements are signed
 using the defined <a>signature algorithm</a>.
       </p>
       <p>
-BBS+ signatures [[BBS]] are compatible with any pairing friendly elliptic curve, however the cryptographic 
+BBS+ signatures [[BBS]] are compatible with any pairing friendly elliptic curve, however the cryptographic
 suites defined in this document elect to only allow the usage of the BLS12-381 for interoperability purposes.
       </p>
-    </section>
 
     <section>
       <h2>Terminology</h2>
@@ -282,17 +281,17 @@ A <a>linked data document</a> featuring one or more <a>data integrity proofs</a>
       </dd>
       <dt><dfn data-lt="revealed statements">revealed statements</dfn></dt>
       <dd>
-The set of <a>statements</a> produced by applying the <a>canonicalization algorithm</a> to the <a>reveal document</a>. 
+The set of <a>statements</a> produced by applying the <a>canonicalization algorithm</a> to the <a>reveal document</a>.
       </dd>
       <dt><dfn>derive proof algorithm</dfn></dt>
       <dd>
-An algorithm that takes in a <a>data integrity proof document</a> featuring a <a>data integrity proof</a> that supports a 
-<a>derive proof algorithm</a> along side a <a>reveal document</a> 
-and derives a proof only revealing the <a>statement</a>s defined in the <a>reveal document</a>. 
+An algorithm that takes in a <a>data integrity proof document</a> featuring a <a>data integrity proof</a> that supports a
+<a>derive proof algorithm</a> along side a <a>reveal document</a>
+and derives a proof only revealing the <a>statement</a>s defined in the <a>reveal document</a>.
       </dd>
       <dt><dfn>derived proof</dfn></dt>
       <dd>
-The product of apply the <a>derive proof algorithm</a> to an <a>data integrity proof document</a> and <a>reveal document</a>. 
+The product of apply the <a>derive proof algorithm</a> to an <a>data integrity proof document</a> and <a>reveal document</a>.
       </dd>
       <dt><dfn data-lt="quad|quads">quad</dfn></dt>
       <dd>
@@ -304,7 +303,7 @@ An <a href="https://www.w3.org/TR/n-quads/" class="externalDFN">n-quad</a> which
       </dd>
       <dt><dfn data-lt="data integrity proof|data integrity proofs">data integrity proof</dfn></dt>
       <dd>
-A <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-data-integrity-proof" class="externalDFN">data integrity proof</a> 
+A <a href="https://w3c-ccg.github.io/data-integrity-spec/#dfn-data-integrity-proof" class="externalDFN">data integrity proof</a>
 which is a set of attributes that represent a linked data digital proof and the parameters required to verify it as defined by [[RDF-N-Quads]].
       </dd>
       <dt><dfn data-lt="linked data document|linked data documents">linked data document</dfn></dt>
@@ -318,8 +317,8 @@ The name defining a particular cryptographic curve.
       <dt><dfn data-lt="frame">frame</dfn></dt>
       <dd>
 A <a href="https://www.w3.org/TR/json-ld11/#dfn-frame" class="externalDFN">frame</a> as specified by [[JSON-LD-FRAMING]]
-is a <a>JSON-LD document</a>, which describes the form for transforming another JSON-LD 
-document using matching and embedding rules. A frame document allows additional 
+is a <a>JSON-LD document</a>, which describes the form for transforming another JSON-LD
+document using matching and embedding rules. A frame document allows additional
 keywords and certain map entries to describe the matching and transforming process.
       </dd>
       <dt><dfn>JSON-LD document</dfn></dt>
@@ -340,36 +339,57 @@ In short, it is a node in a graph that is neither an IRI, nor a literal.
       </dl>
     </section>
 
-    
+      <section id="conformance">
+
+      <div class="issue">TODO: Add paragraph</div>
+
+      </section>
+    </section>
+
+
+    <section>
+      <h2>Security Considerations</h2>
+      <p>
+The following section describes security considerations that developers
+implementing this specification should be aware of in order to create secure
+software.
+      </p>
+
+<div class="issue">TODO: We need to add a complete list of security
+considerations.</div>
+    </section>
+
+  <section class="appendix">
+    <h1>BBS+ Signature 2020</h1>
 
     <section>
       <h2>BLS12-381</h2>
       <p>
-Defined in [[PAIRING-FRIENDLY-CURVES]], BLS12-381 is an elliptic curve that features a unique property 
-only present in a subset of elliptic curves known as being pairing friendly.  
+Defined in [[PAIRING-FRIENDLY-CURVES]], BLS12-381 is an elliptic curve that features a unique property
+only present in a subset of elliptic curves known as being pairing friendly.
       </p>
       <p>
 Because of the pairing friendly property, BLS12-381 can be used to construct digital signatures
 that have unique properties, such as aggregatable signatures and or signatures
 that support zero knowledge proof disclosure.
       </p>
-      
+
 
 <div class="issue">TODO: Is the the below the correct place for the rationale?</div>
 
       <p>
-With pairing friendly elliptic curves, there are two fields, denoted G1 and G2, for 
+With pairing friendly elliptic curves, there are two fields, denoted G1 and G2, for
 which signatures and public keys can exist. Importantly however both the public
 key and a signature generated using the public key cannot exist in the same field.
       </p>
       <p>
 Due to the properties of the two fields, there are different associated performance
-characteristics to selecting which field to use for signatures vs which field to use 
-for public key generation. In general operations are faster in G1 and the resulting commitments 
+characteristics to selecting which field to use for signatures vs which field to use
+for public key generation. In general operations are faster in G1 and the resulting commitments
 are smaller. With this definition of BBS+ signatures we have opted for signatures to be faster
 and smaller to create rather than key generation.
       </p>
-        
+
   <section>
     <h3><dfn>Bls 12-381 G1 Public Key</dfn></h3>
 
@@ -378,9 +398,9 @@ and smaller to create rather than key generation.
     </p>
 
     <p>
-      The keys definition MUST have an attribute of <code>publicKeyBase58</code> and its value 
-      MUST be a base58 encoded BLS12-381 public key in the G1 field. Where the 
-      BLS12-381 public key is the raw 48 byte x co-ordinate defining the commitment. 
+      The keys definition MUST have an attribute of <code>publicKeyBase58</code> and its value
+      MUST be a base58 encoded BLS12-381 public key in the G1 field. Where the
+      BLS12-381 public key is the raw 48 byte x co-ordinate defining the commitment.
     </p>
       <p>
       A simple example of a <a>Bls12381G1Key2020</a>:
@@ -416,10 +436,10 @@ and smaller to create rather than key generation.
     </p>
 
     <p>
-      The keys definition MUST have an attribute of <code>publicKeyBase58</code> and its value 
-      MUST be a base58 encoded BLS12-381 public key in the G2 field. Where the 
+      The keys definition MUST have an attribute of <code>publicKeyBase58</code> and its value
+      MUST be a base58 encoded BLS12-381 public key in the G2 field. Where the
       BLS12-381 public key is the concatenation of the 2 raw 48 byte x co-ordinates
-      defining the commitment. 
+      defining the commitment.
     </p>
       <p>
       A simple example of a <a>Bls12381G2Key2020</a>:
@@ -446,10 +466,10 @@ and smaller to create rather than key generation.
         }
       </pre>
   </section>
-        
+
     </section>
 
-    
+
     <section>
       <h2>The BBS+ Signature Suite 2020</h2>
 
@@ -459,7 +479,7 @@ and smaller to create rather than key generation.
         Data Integrity [[DATA-INTEGRITY]] specification. The suite consists of
         the following algorithms:
               </p>
-        
+
               <table class="simple">
                 <thead>
                   <th>Parameter</th>
@@ -489,7 +509,7 @@ and smaller to create rather than key generation.
                   </tr>
                 </tbody>
               </table>
-        
+
       <section>
         <h3>Modification to Algorithms</h3>
 
@@ -497,8 +517,8 @@ and smaller to create rather than key generation.
           <h4>Create Verify Data Algorithm</h4>
 
           <p>
-            In order to support <a>selective disclosure</a> of <a>statements</a>, 
-            the create verify data algorithm has been modified from 
+            In order to support <a>selective disclosure</a> of <a>statements</a>,
+            the create verify data algorithm has been modified from
             its original <a href="https://w3c-ccg.github.io/data-integrity-spec/#create-verify-hash-algorithm"></a>definition</a>.
           </p>
 
@@ -513,28 +533,28 @@ and smaller to create rather than key generation.
               <li>For each <a>statement</a> in order:
                 <ol class="algorithm">
                   <li>Apply the <a>statement digest algorithm</a> to obtain a <a>statement digest</a></li>
-                  <li>Insert the <a>statement digest</a> into the <a>statement digests</a> array which MUST maintain same order as the order 
+                  <li>Insert the <a>statement digest</a> into the <a>statement digests</a> array which MUST maintain same order as the order
                     of the statements returned from the <a>canonicalization algorithm</a>.</li>
                 </ol>
               <li>Returned the <a>statement digests</a> array.</li>
             </ol>
 
         </section>
-        
+
       </section>
 
       <section>
         <h3>Terms</h3>
-        
+
         <p>
           The following section outlines the terms used by the BBS+ Signature Suite.
         </p>
 
         <section>
           <h4>Proof Type</h4>
-          
+
           <p>
-            To identify the type of <a>data integrity proof</a> that is attached to a <a>linked data document</a>, 
+            To identify the type of <a>data integrity proof</a> that is attached to a <a>linked data document</a>,
             the <code>type</code> attribute <a href="https://w3c-ccg.github.io/data-integrity-spec/#proofs">defined</a> in
             [[DATA-INTEGRITY]].
           </p>
@@ -544,7 +564,7 @@ and smaller to create rather than key generation.
           </p>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> 
+            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a>
             MUST contain a proof element thats has a type equal to <code>BbsBlsSignature2020</code>.
           </p>
 
@@ -584,7 +604,7 @@ and smaller to create rather than key generation.
           </p>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MAY contain a <code>created</code> 
+            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MAY contain a <code>created</code>
             attribute with value a value corresponding to an [[!ISO8601]] combined date and time string.
           </p>
 
@@ -616,11 +636,11 @@ and smaller to create rather than key generation.
         <section>
           <h4>@context</h4>
 
-          <p> 
-            When using [[JSON-LD]] to exchange data between more than one software system, it's important to use terminology that both of the software systems can understand. 
+          <p>
+            When using [[JSON-LD]] to exchange data between more than one software system, it's important to use terminology that both of the software systems can understand.
             In [[JSON-LD]] this common terminology is identified with the usage of URIs. However, those URIs can be long and not human friendly for implementors to work with.
             In such cases, aliases that are presented in a short-form can be used to ease this burden. This specification relies on the <code>@context</code> property in [[JSON-LD]]
-            to short-form aliases to long form URIs required by this <a>signature suite</a>. It's RECOMMENDED that <code>https://w3id.org/security/bbs/v1</code> is used within the 
+            to short-form aliases to long form URIs required by this <a>signature suite</a>. It's RECOMMENDED that <code>https://w3id.org/security/bbs/v1</code> is used within the
             <code>@context</code> property to map the short-form aliases to long form URIs.
           </p>
 
@@ -658,15 +678,15 @@ and smaller to create rather than key generation.
           </p>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MUST contain a <code>verificationMethod</code> 
+            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MUST contain a <code>verificationMethod</code>
             attribute with a value that is either the verification method required to verify the <a>data integrity proof</a> or a URI that when dereferenced
-            results in the verification method required to verify the <a>data integrity proof</a>. 
+            results in the verification method required to verify the <a>data integrity proof</a>.
           </p>
           <p>
             The verification method MUST be of <code>type</code> <a>Bls12381G2Key2020</a>.
           </p>
 
-      
+
           <pre class="example nohighlight">
             {
               "@context": [
@@ -701,7 +721,7 @@ and smaller to create rather than key generation.
           </p>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MUST contain a <code>proofPurpose</code> 
+            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MUST contain a <code>proofPurpose</code>
             attribute with a value that is <a href="https://w3c-ccg.github.io/data-integrity-spec/#proof-purpose">defined</a> in [[DATA-INTEGRITY]].
           </p>
 
@@ -739,13 +759,13 @@ and smaller to create rather than key generation.
           </p>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MUST contain a <code>requiredRevealStatements</code> 
-            attribute with a value that is an array of un-signed integers representing the indicies of the statements in the <a>canonical form</a> 
-            that MUST always be revealed in a <a>derived proof</a>. The indicies corresponding to the statements for the <code>verificationMethod</code> 
+            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MUST contain a <code>requiredRevealStatements</code>
+            attribute with a value that is an array of un-signed integers representing the indicies of the statements in the <a>canonical form</a>
+            that MUST always be revealed in a <a>derived proof</a>. The indicies corresponding to the statements for the <code>verificationMethod</code>
             and <code>proofPurpose</code> as apart of the <a>data integrity proof</a> MUST always be present.
           </p>
 
-    
+
           <pre class="example nohighlight">
             {
               "@context": [
@@ -779,7 +799,7 @@ and smaller to create rather than key generation.
           </p>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MUST contain a <code>proofValue</code> 
+            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MUST contain a <code>proofValue</code>
             attribute with value defined by the signing algorithm described in this specification.
           </p>
 
@@ -857,7 +877,7 @@ the following algorithms:
 
       <section>
         <h3>Terms</h3>
-        
+
         <p>
           The following section outlines the terms used by the BBS+ proof of knowledge <a>signature suite</a>.
         </p>
@@ -866,7 +886,7 @@ the following algorithms:
           <h4>Proof Type</h4>
 
           <p>
-            To identify the type of <a>data integrity proof</a> that is attached to a <a>linked data document</a>, 
+            To identify the type of <a>data integrity proof</a> that is attached to a <a>linked data document</a>,
             the <code>type</code> attribute is used as <a href="https://w3c-ccg.github.io/data-integrity-spec/#proofs">defined</a> in
             [[DATA-INTEGRITY]].
           </p>
@@ -876,7 +896,7 @@ the following algorithms:
           </p>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ proof of knowledge <a>data integrity proof</a> 
+            A <a>linked data document</a> featuring a BBS+ proof of knowledge <a>data integrity proof</a>
             MUST contain a <code>type</code> attribute thats has a type equal to <code>BbsSignatureProof2020</code>.
           </p>
 
@@ -911,7 +931,7 @@ the following algorithms:
           <div class="issue">TODO: Add paragraph?</div>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MAY contain a <code>created</code> 
+            A <a>linked data document</a> featuring a BBS+ Signature <a>data integrity proof</a> MAY contain a <code>created</code>
             attribute with value a value corresponding to an [[!ISO8601]] combined date and time string.
           </p>
 
@@ -944,10 +964,10 @@ the following algorithms:
           <h4>Verification Method</h4>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ proof of knowledge <a>data integrity proof</a> MUST contain a <code>verificationMethod</code> 
+            A <a>linked data document</a> featuring a BBS+ proof of knowledge <a>data integrity proof</a> MUST contain a <code>verificationMethod</code>
             attribute with a value that is equal to that of the <a>BbsBlsSignature2020</a> for which the proof is derived from.
           </p>
-          
+
           <div class="issue">TODO: Add paragraph?</div>
 
           <pre class="example nohighlight">
@@ -981,7 +1001,7 @@ the following algorithms:
           <div class="issue">TODO: Add paragraph?</div>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ proof of knowledge <a>data integrity proof</a> MUST contain a <code>proofPurpose</code> 
+            A <a>linked data document</a> featuring a BBS+ proof of knowledge <a>data integrity proof</a> MUST contain a <code>proofPurpose</code>
             attribute with a value that is equal to that of the <a>BbsBlsSignature2020</a> for which the proof is derived from.
           </p>
 
@@ -1058,7 +1078,7 @@ the following algorithms:
           </p>
 
           <p>
-            A <a>linked data document</a> featuring a BBS+ proof of knowledge <a>data integrity proof</a> 
+            A <a>linked data document</a> featuring a BBS+ proof of knowledge <a>data integrity proof</a>
             MUST contain a <code>nonce</code> attribute.
           </p>
 
@@ -1344,7 +1364,7 @@ value of <code>BbsBoundSignatureProof2020</code>.
       <h2>Derive Proof Algorithm</h2>
 
       <p>
-        In order to support <a>selective disclosure</a> of <a>statements</a>, 
+        In order to support <a>selective disclosure</a> of <a>statements</a>,
         the following <a>derive proof algorithm</a> has been defined.
       </p>
 
@@ -1352,7 +1372,7 @@ value of <code>BbsBoundSignatureProof2020</code>.
 
       <section>
         <h4>Create Derive Proof Data Algorithm</h4>
-        
+
         <p>
           The following algorithm defined below outlines the process of obtaining the inputs into the <a>derive proof algorithm</a>.
         </p>
@@ -1379,7 +1399,7 @@ value of <code>BbsBoundSignatureProof2020</code>.
               represented as <a>n-quads</a>. Let this set be known as the <dfn>input proof document statements</dfn>.
             </li>
             <li>
-              Record the total number of <a>statements</a> in the <a>input proof document statements</a>. 
+              Record the total number of <a>statements</a> in the <a>input proof document statements</a>.
               Let this be known as the <a>total statements</a>.
             </li>
             <li>
@@ -1387,11 +1407,11 @@ value of <code>BbsBoundSignatureProof2020</code>.
               known as the <a>revealed document</a>.
             </li>
             <li>
-              Canonicalize the <a>revealed document</a> using the <a>canonicalization algorithm</a> to obtain the set of <a>statements</a> 
+              Canonicalize the <a>revealed document</a> using the <a>canonicalization algorithm</a> to obtain the set of <a>statements</a>
               represented as <a>n-quads</a>. Let these be known as the <a>revealed statements</a>.
             </li>
             <li>
-              Initialize an empty array of length equal to the number of <a>revealed statements</a>. 
+              Initialize an empty array of length equal to the number of <a>revealed statements</a>.
               Let this be known as the <a>revealed indicies</a> array.
             </li>
             <li>For each <a>statement</a> in order:
@@ -1402,39 +1422,24 @@ value of <code>BbsBoundSignatureProof2020</code>.
             <li>Returned the <a>revealed indicies</a> array, <a>total statements</a> and <a>input proof document statements</a>.</li>
           </ol>
           <div class="issue">TODO: Define how we have to validate the requiredRevealStatements</div>
-          
+
           <div class="issue">TODO: Add a comment on how we diff the input proof document and the reveal
             document to produce get the correct node identifiers for the reveal document</div>
       </section>
 
     </section>
 
-    <section id="conformance">
-
-    <div class="issue">TODO: Add paragraph</div>
-
     </section>
 
-    <section>
-      <h2>Security Considerations</h2>
-      <p>
-The following section describes security considerations that developers
-implementing this specification should be aware of in order to create secure
-software.
-      </p>
-
-<div class="issue">TODO: We need to add a complete list of security
-considerations.</div>
-    </section>
     <section class="appendix">
       <h2>Acknowledgements</h2>
       <p>
         Portions of the work on this specification have been funded by the
         United States Department of Homeland Security's (US DHS) Silicon Valley
-        Innovation Program under contracts 
-        70RSAT20T00000003, 
+        Innovation Program under contracts
+        70RSAT20T00000003,
         and
-        70RSAT20T00000033. 
+        70RSAT20T00000033.
         The content of this specification does not
         necessarily reflect the position or the policy of the U.S. Government
         and no official endorsement should be inferred.


### PR DESCRIPTION
This PR updates the data model and algorithms sections to align with the new algorithm layout for the Data Integrity specification. 

The PR specifically does not remove any text, but rather moves the legacy BBS 2020 algorithm text into an appendix (which the Editor's may decide to keep, refactor, integrate, or delete). The PR also does not attempt to make a decision regarding the bound vs. unbound BBS Signatures.

The PR provides key representations in both `publicKeyMultibase` and `JsonWebKey` format, and I expect there needs to be further discussion about that section given that each key format takes a different approach. I do not claim to know or understand the trade-offs at this point in time, so no amount of finality about the serialization format for BBS pubic keys should be assumed about this PR.

All that to say: I'm only trying to be helpful in formatting this specification into a form that aligns with the layout of the other data integrity specifications. I defer completely to the implementers at CFRG to fix whatever I have broken and make the right judgement calls as to the appropriate normative content in this specification. This PR is just one step in the journey to a complete and implementable BBS Data Integrity Cryptosuite specification.